### PR TITLE
Change of file organization and support 64-bit binary build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.swp
 *.o
-eserv
+# A leading slash matches the beginning of the pathname. For example, "/*.c" matches "cat-file.c" but not "mozilla-sha1/sha1.c"
+# ignore only binary eserv which located in the same directory as .gitignore not library eserv!
+/eserv
 *.a

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,9 @@ CFLAGS = -Os -Wextra \
 	 -Iinclude
 # -D NDEBUG
 
-CFLAGS += -m32
+# CFLAGS += -m32
+CFLAGS += -m64
+CFLAGS += -D NDEBUG
 LIBS = -Llib/eserv
 LDFLAGS = -leserv -lpthread -lcrypt
 
@@ -25,7 +27,9 @@ OBJS = main.o \
 all: $(PROG)
 
 $(PROG): $(OBJS)
+	@cd lib/eserv;make all;
 	$(CC) -o $(PROG) $(CFLAGS) $(OBJS) $(LDFLAGS) $(LIBS)
 
 clean:
+	@cd lib/eserv;make clean;
 	rm -f $(PROG) $(OBJS)

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,7 @@ CFLAGS = -Os -Wextra \
 	 $(SOURCE_FLAGS) -g \
 	 -std=gnu99 \
 	 -Iinclude
-# -D NDEBUG
 
-# CFLAGS += -m32
-CFLAGS += -m64
 CFLAGS += -D NDEBUG
 LIBS = -Llib/eserv
 LDFLAGS = -leserv -lpthread -lcrypt

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,7 @@ CFLAGS += -D NDEBUG
 LIBS = -Llib/eserv
 LDFLAGS = -leserv -lpthread -lcrypt
 
-OBJS = main.o \
-	cgi_custom.o
+OBJS = main.o
 
 .c.o:
 	$(CC) $(CFLAGS) -c $*.c

--- a/include/eserv/cgi_custom.h
+++ b/include/eserv/cgi_custom.h
@@ -1,7 +1,8 @@
 #ifndef __CGI_CUSTOM_H__
 #define __CGI_CUSTOM_H__
 
-#include "eserv/cgi.h"
+// #include "eserv/cgi.h"
+#include "cgi.h"
 
 extern int cgi_page_sum(ExHttp *pHttp);
 extern int cgi_page_txt(ExHttp *pHttp);
@@ -37,13 +38,13 @@ cgi_page cgi_pages[] = {
 	},
 };
 
-void register_cgi(){
-	size_t i;
-	for (i = 0; i < sizeof(cgi_pages) / sizeof(cgi_page); i++)
-		cgi_page_add(cgi_pages[i].name,
-			cgi_pages[i].callback);
-
-}
+// void register_cgi(){
+// 	size_t i;
+// 	for (i = 0; i < sizeof(cgi_pages) / sizeof(cgi_page); i++)
+// 		cgi_page_add(cgi_pages[i].name,
+// 			cgi_pages[i].callback);
+//
+// }
 
 #endif
 

--- a/include/eserv/cgi_custom.h
+++ b/include/eserv/cgi_custom.h
@@ -1,7 +1,6 @@
 #ifndef __CGI_CUSTOM_H__
 #define __CGI_CUSTOM_H__
 
-// #include "eserv/cgi.h"
 #include "cgi.h"
 
 extern int cgi_page_sum(ExHttp *pHttp);
@@ -37,14 +36,4 @@ cgi_page cgi_pages[] = {
 		.callback = cgi_hash_test,
 	},
 };
-
-// void register_cgi(){
-// 	size_t i;
-// 	for (i = 0; i < sizeof(cgi_pages) / sizeof(cgi_page); i++)
-// 		cgi_page_add(cgi_pages[i].name,
-// 			cgi_pages[i].callback);
-//
-// }
-
 #endif
-

--- a/lib/eserv/Makefile
+++ b/lib/eserv/Makefile
@@ -11,9 +11,6 @@ CFLAGS = -Os -Wall -Wextra \
 	-std=gnu99 \
 	-I../../include/eserv
 
-# CFLAGS += -m32
-CFLAGS += -m64
-
 LDFLAGS = -lpthread -lcrypt
 
 OBJS = \

--- a/lib/eserv/Makefile
+++ b/lib/eserv/Makefile
@@ -11,7 +11,8 @@ CFLAGS = -Os -Wall -Wextra \
 	-std=gnu99 \
 	-I../../include/eserv
 
-CFLAGS += -m32
+# CFLAGS += -m32
+CFLAGS += -m64
 
 LDFLAGS = -lpthread -lcrypt
 
@@ -25,7 +26,8 @@ OBJS = \
 	entry.o \
 	cgi.o \
 	misc.o \
-	session.o
+	session.o \
+	cgi_custom.o
 
 .c.o:
 	$(CC) $(CFLAGS)  -c $*.c

--- a/lib/eserv/cgi.c
+++ b/lib/eserv/cgi.c
@@ -1,19 +1,14 @@
 #include "cgi.h"
-
-// after ex_init() register the cgi
-/* FIXME : flexible inclusion of customized CGI */
-//#include "../cgi_custom.h"
+#include "cgi_custom.h"
 
 extern cgi_page cgi_pages[];
 
 void cgi_init()
 {
-/*
 	size_t i;
 	for (i = 0; i < sizeof(cgi_pages) / sizeof(cgi_page); i++)
 		cgi_page_add(cgi_pages[i].name,
 		             cgi_pages[i].callback);
-*/
 }
 
 void cgi_uninit()

--- a/lib/eserv/cgi_custom.c
+++ b/lib/eserv/cgi_custom.c
@@ -1,5 +1,5 @@
-#include "eserv/cgi.h"
-#include "eserv/session.h"
+#include "cgi.h"
+#include "session.h"
 
 int cgi_page_sum(ExHttp *pHttp)
 {

--- a/main.c
+++ b/main.c
@@ -1,12 +1,10 @@
 #include "eserv/http.h"
-#include "cgi_custom.h"
 
 int main()
 {
 	char buf[16];
 
 	ex_init();
-	register_cgi();
 
 	while (scanf("%16s", buf) > 0) {
 		if (strncmp("quit", buf, 4) == 0)


### PR DESCRIPTION
Moved cgi scripts related files (cgi_custom.h and cgi_custom.c) into eserv library (lib/eserv) and remove 32-bit only binary build from Makefiles.
